### PR TITLE
Use single quotes to allow all characters in password

### DIFF
--- a/nsupdate.d/sample.config.dist
+++ b/nsupdate.d/sample.config.dist
@@ -9,7 +9,7 @@ IPV6="NO"
 
 # Login credentials for the inwx admin interface
 INWX_USER="USERNAME"
-INWX_PASS="PASSWORD"
+INWX_PASS='PASSWORD'
 
 # The hostname that you want to update and it's ID from the inwx interface
 # You get the ID when you edit the given nameserver entry and hover the save button.


### PR DESCRIPTION
Several characters e.g. $ are not correctly escaped using double quotes.