### PR TITLE
added support for mx records and some sort of silent ouput/logs

### DIFF
--- a/nsupdate.d/sample.config.dist
+++ b/nsupdate.d/sample.config.dist
@@ -6,6 +6,7 @@ IP_CHECK_SITE="http://ip.dblx.io"
 # use drill instead of nslookup for hostname lookup
 USE_DRILL="YES"
 IPV6="NO"
+MX="NO"
 
 # Login credentials for the inwx admin interface
 INWX_USER="USERNAME"

--- a/nsupdate.sh
+++ b/nsupdate.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/bin/bash
 
 # Update a nameserver entry at inwx with the current WAN IP (DynDNS)
 
@@ -25,16 +25,23 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 LOG=$0.log
-
+SILENT=NO
 # Loop through configs
 for f in $(dirname $0)/nsupdate.d/*.config
 do
-   echo "Starting nameserver update with config file $f"
+   if [ "$SILENT" == "NO" ]; then
+      echo "Starting nameserver update with config file $f"
+   fi
    ## Set record type to IPv4
    TYPE=A
    CONNECTION_TYPE=4
 
    source $f
+
+   ## Set record type to MX
+   if [[ "$MX" == "YES" ]]; then
+      TYPE=MX
+   fi
 
    ## Set record type to IPv6
    if [[ "$IPV6" == "YES" ]]; then
@@ -43,13 +50,24 @@ do
    fi
 
    if [[ "$USE_DRILL" == "YES" ]]; then
-      NSLOOKUP=$(drill $DOMAIN @ns.inwx.de $TYPE | head -7 | tail -1 | awk '{print $5}')   
+      if [[ "$TYPE" == "MX" ]]; then
+		echo looking up MX records with drill currently not supported!
+		exit 1;
+	  else
+	    NSLOOKUP=$(drill $DOMAIN @ns.inwx.de $TYPE | head -7 | tail -1 | awk '{print $5}')   
+	  fi
    else
-      NSLOOKUP=$(nslookup -sil -type=$TYPE $DOMAIN - ns.inwx.de | tail -2 | head -1 | cut -d' ' -f2)
+   	  if [[ "$TYPE" == "MX" ]]; then
+		PART_NSLOOKUP=$(nslookup -sil -type=$TYPE $DOMAIN - ns.inwx.de | tail -2 | head -1 | cut -d' ' -f5)
+		NSLOOKUP=${PART_NSLOOKUP%"."}
+      else
+	  	NSLOOKUP=$(nslookup -sil -type=$TYPE $DOMAIN - ns.inwx.de | tail -2 | head -1 | cut -d' ' -f2)
+	  fi
    fi
 
    # WAN_IP=`curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE}| grep -Eo '\<[[:digit:]]{1,3}(\.[[:digit:]]{1,3}){3}\>'`
    WAN_IP=`curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE}`
+
 
    API_XML="<?xml version=\"1.0\"?>
    <methodCall>
@@ -87,16 +105,17 @@ do
          </param>
       </params>
    </methodCall>"
-
+   
    if [ ! "$NSLOOKUP" == "$WAN_IP" ]; then
       curl -silent -v -XPOST -H"Content-Type: application/xml" -d "$API_XML" https://api.domrobot.com/xmlrpc/
       echo "$(date) - $DOMAIN updated. Old IP: "$NSLOOKUP "New IP: "$WAN_IP >> $LOG
-   else
+   elif [ "$SILENT" == "NO" ]; then
       echo "$(date) - No update needed for $DOMAIN. Current IP: "$NSLOOKUP >> $LOG
    fi
 
    unset DOMAIN
    unset IPV6
+   unset MX
    unset WAN_IP
    unset NSLOOKUP
    unset INWX_PASS


### PR DESCRIPTION
MX Records:
        if the DOMAIN specified in the .config file is actually an mx
        record then set MX=YES in your .config file.
	currently only supported when using nslookup and not drill.

added SILENT mode:
	if SILENT is set to NO the output and the logmessages
	remain the same.
        if SILENT is set to something else than NO or not set then
	neither will there be an output nor a log message as long
	as the ip-address doesn't change.