### PR TITLE
Change IP_CHECK_SITE to https://api.ipify.org/

### DIFF
--- a/nsupdate.d/sample.config.dist
+++ b/nsupdate.d/sample.config.dist
@@ -4,7 +4,7 @@
 LOG="$0.log"
 
 # From which site should we get your WAN IP?
-IP_CHECK_SITE="https://ip.dblx.io"
+IP_CHECK_SITE="https://api.ipify.org/"
 
 # Use drill instead of nslookup for hostname lookup.
 USE_DRILL="NO"


### PR DESCRIPTION
The old one "https://ip.dblx.io/" returns "File not Found" since a few days.
So i changed the default site to "https://api.ipify.org/"