### PR TITLE
Add a way to specify the IP without using curl and an external site

### DIFF
--- a/nsupdate.d/dist.config.sample
+++ b/nsupdate.d/dist.config.sample
@@ -44,6 +44,9 @@ LOG="$0.log"
 #       inspecting the target URL of the save button.
 #INWX_DOMAIN_ID="123456789"
 
+# Provide a command to get the Ip instead of using Curl
+#IPCOMMAND=""
+
 # Use IPv6 connection.
 # deprecated option for backward compatibility, use TYPE instead
 #IPV6="NO"

--- a/nsupdate.sh
+++ b/nsupdate.sh
@@ -94,10 +94,10 @@ if ls $(dirname $0)/nsupdate.d/*.config &> /dev/null; then
       fi
 
       # WAN_IP=`curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE}| grep -Eo '\<[[:digit:]]{1,3}(\.[[:digit:]]{1,3}){3}\>'`
-      if [[ -n "$IPCOMMAND" ]]; then
-        WAN_IP=$($IPCOMMAND)
-      else
+      if [[ -z ${IPCOMMAND} ]]; then
         WAN_IP=$(curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE})
+      else
+        WAN_IP=$($IPCOMMAND)
       fi
 
       # This is relevant for getting the specific domain record id.

--- a/nsupdate.sh
+++ b/nsupdate.sh
@@ -94,7 +94,11 @@ if ls $(dirname $0)/nsupdate.d/*.config &> /dev/null; then
       fi
 
       # WAN_IP=`curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE}| grep -Eo '\<[[:digit:]]{1,3}(\.[[:digit:]]{1,3}){3}\>'`
-      WAN_IP=$(curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE})
+      if [[ -n "$IPCOMMAND" ]]; then
+        WAN_IP=$($IPCOMMAND)
+      else
+        WAN_IP=$(curl -s -$CONNECTION_TYPE ${IP_CHECK_SITE})
+      fi
 
       # This is relevant for getting the specific domain record id.
       API_XML_INFO="<?xml version=\"1.0\"?>


### PR DESCRIPTION
Hey. Thanks for this repository. It helped me greatly already.

This patch allows to specify a different command to obtain the IP address.
This could for example be useful if you want to update the IP of a running LXC Container from the host.